### PR TITLE
Fix programming language not being detected

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+twitter-to-nitter.js linguist-generated=false


### PR DESCRIPTION
For some reason, the programming language of JavaScript is not being detected unlike in [the other extension repo](https://github.com/jesseojones/reddit-to-old-reddit), so adding a git attributes file along with appropriate Linguist property to resolve.